### PR TITLE
Workflow: Add Windows ARM & ARM64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,23 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
     strategy:
       matrix:
-        arch: [x64, x86]
+        include:
+          - arch: "x64"
+            target: "x64"
+            runner: windows-latest
+          - arch: "x86"
+            target: "x86"
+            runner: windows-latest
+          - arch: "arm64"
+            target: "arm64"
+            runner: windows-11-arm
+          - arch: "arm"
+            target: "amd64_arm"
+            runner: windows-latest
+            winsdk: "10.0.22621.0"
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       
@@ -23,13 +36,56 @@ jobs:
       - name: Install Meson and Ninja
         run: pip install meson ninja
       
-      - name: Setup MSVC
+      - name: Install Windows SDK 10.0.22621.0 C++ ARM Tools
+        uses: ChristopheLav/windows-sdk-install@v1.0.4
+        if: matrix.arch == 'arm'
+        with:
+          version-sdk: 22621
+          features: 'OptionId.DesktopCPParm'
+
+      - name: Setup MSVC (native)
+        if: matrix.arch != 'arm'
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.target }}
       
-      - name: Configure
+      - name: Setup MSVC (arm 10.0.22621.0 cross)
+        if: matrix.arch == 'arm'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.target }}
+          sdk: ${{ matrix.winsdk }}
+
+      - name: Create cross-compilation file
+        if: matrix.arch == 'arm'
+        shell: pwsh
+        run: |
+          Set-Content windows-${{ matrix.arch }}.txt @'
+          [binaries]
+          c = 'cl.exe'
+          cpp = 'cl.exe'
+          exe_wrapper = 'dumpbin.exe'
+
+          [build_machine]
+          system = 'windows'
+          cpu_family = 'x86_64'
+          cpu = 'x86_64'
+          endian = 'little'
+
+          [host_machine]
+          system = 'windows'
+          cpu_family = '${{ matrix.arch }}'
+          cpu = '${{ matrix.arch }}'
+          endian = 'little'
+          '@
+
+      - name: Configure (native)
+        if: matrix.arch != 'arm'
         run: meson setup builddir --prefix=${{ github.workspace }}/install -Ddefault_library=static -Db_vscrt=static_from_buildtype
+
+      - name: Configure (cross)
+        if: matrix.arch == 'arm'
+        run: meson setup builddir --prefix=${{ github.workspace }}/install -Ddefault_library=static -Db_vscrt=static_from_buildtype --cross-file windows-${{ matrix.arch }}.txt
       
       - name: Build
         run: meson compile -C builddir


### PR DESCRIPTION
I realised that my Windows builds fork is likely no longer necessary since you rewrote your code and switched to Meson, meaning it compiles on Windows without modifications (nice work by the way!).

I see you're already building automatically for x64 and x86 Windows, and this PR adds ARM and ARM64 builds to the workflow. The ARM64 build is compiled natively with the Windows 11 ARM runner, while the ARM32 build is cross-compiled on x64. The last Windows 11 SDK to support ARM32 is 22621 so the workflow now fetches this SDK for that build specifically and also generates the Meson cross file. This brings the Windows arch coverage in line with the Linux/Android builds.

I have tested the updated workflow [here](https://github.com/TheFreeman193/android-xml-converter-windows/actions/runs/19788450371) to confirm the new ARM(64) steps succeed and tested the [release artifacts](https://github.com/TheFreeman193/android-xml-converter-windows/releases/tag/build-6) to confirm the 4 Windows builds run and can interconvert XML and ABX (tested with a packages.xml file from an Android 15 LineageOS device).